### PR TITLE
Add Gamification test and module

### DIFF
--- a/gamification.py
+++ b/gamification.py
@@ -1,0 +1,6 @@
+class Gamification:
+    def update_leaderboard(self, user_id, user_points):
+        """Return leaderboard list with a single tuple of user_id and user_points."""
+        leaderboard = []
+        leaderboard.append((user_id, user_points))
+        return leaderboard

--- a/tests/test_gamification.py
+++ b/tests/test_gamification.py
@@ -1,0 +1,17 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from gamification import Gamification
+
+
+def test_update_leaderboard_returns_correct_list():
+    gamification = Gamification()
+    result = gamification.update_leaderboard('user1', 100)
+    assert result == [('user1', 100)]
+
+
+if __name__ == '__main__':
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
## Summary
- implement a simple `Gamification` module with `update_leaderboard`
- add pytest for `update_leaderboard`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f1baa1b34832a95ad5498b133b030